### PR TITLE
ceph: expose daemon admin-sockets

### DIFF
--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -49,6 +49,7 @@ const (
 	volumeMountSubPath                    = "data"
 	crashVolumeName                       = "rook-ceph-crash"
 	daemonSocketDir                       = "/run/ceph"
+	daemonSocketVolumeName                = "rook-ceph-run"
 	initialDelaySecondsNonOSDDaemon int32 = 10
 	initialDelaySecondsOSDDaemon    int32 = 45
 	logCollector                          = "log-collector"
@@ -167,6 +168,7 @@ func PodVolumes(dataPaths *config.DataPathMap, dataDirHostPath string, confGener
 		configVolume,
 	}
 	v = append(v, StoredLogAndCrashVolume(dataPaths.HostLogDir(), dataPaths.HostCrashDir())...)
+	v = append(v, DaemonSocketVolume())
 
 	return v
 }
@@ -185,6 +187,7 @@ func CephVolumeMounts(dataPaths *config.DataPathMap, confGeneratedInPod bool) []
 		// Rook doesn't run in ceph containers, so it doesn't need the config override mounted
 	}
 	v = append(v, StoredLogAndCrashVolumeMount(dataPaths.ContainerLogDir(), dataPaths.ContainerCrashDir())...)
+	v = append(v, DaemonSocketVolumeMount())
 
 	return v
 }
@@ -209,6 +212,7 @@ func DaemonVolumesBase(dataPaths *config.DataPathMap, keyringResourceName string
 		// logs are not persisted to host
 		vols = append(vols, StoredLogAndCrashVolume(dataPaths.HostLogDir(), dataPaths.HostCrashDir())...)
 	}
+	vols = append(vols, DaemonSocketVolume())
 	return vols
 }
 
@@ -275,6 +279,7 @@ func DaemonVolumeMounts(dataPaths *config.DataPathMap, keyringResourceName strin
 		// logs are not persisted to host, so no mount is needed
 		mounts = append(mounts, StoredLogAndCrashVolumeMount(dataPaths.ContainerLogDir(), dataPaths.ContainerCrashDir())...)
 	}
+	mounts = append(mounts, DaemonSocketVolumeMount())
 	if dataPaths.ContainerDataDir == "" {
 		// no data is stored in container, so there are no more mounts
 		return mounts
@@ -462,6 +467,7 @@ func ChownCephDataDirsInitContainer(
 		"ceph:ceph",
 		config.VarLogCephDir,
 		config.VarLibCephCrashDir,
+		daemonSocketDir,
 	)
 	if dpm.ContainerDataDir != "" {
 		args = append(args, dpm.ContainerDataDir)
@@ -551,6 +557,29 @@ func StoredLogAndCrashVolumeMount(varLogCephDir, varLibCephCrashDir string) []v1
 			ReadOnly:  false,
 			MountPath: varLibCephCrashDir,
 		},
+	}
+}
+
+// DaemonSocketVolume returns a pod volume for daemon admin sockets
+func DaemonSocketVolume() v1.Volume {
+	Type := v1.HostPathDirectoryOrCreate
+	return v1.Volume{
+		Name: daemonSocketVolumeName,
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: daemonSocketDir,
+				Type: &Type,
+			},
+		},
+	}
+}
+
+// DaemonSocketVolumeMount defines the volume mount for daemon admin sockets
+func DaemonSocketVolumeMount() v1.VolumeMount {
+	return v1.VolumeMount{
+		Name:      daemonSocketVolumeName,
+		ReadOnly:  false,
+		MountPath: daemonSocketDir,
 	}
 }
 


### PR DESCRIPTION
Exposing admin sockets let us collecting more metrics of ceph services.

Signed-off-by: M. Can Sevinç <can.sevinc@retinadata.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Exposed daemon admin sockets.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/retinadata/wise-up/issues/8

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
